### PR TITLE
small fixes for nvidia.sh and xdph.sh

### DIFF
--- a/install-scripts/nvidia.sh
+++ b/install-scripts/nvidia.sh
@@ -104,7 +104,10 @@ printf "${YELLOW} nvidia-stuff to /etc/default/grub..."
     
   # Define the configuration file and the line to add
     config_file="/etc/modprobe.d/nvidia.conf"
-    line_to_add="options nvidia-drm modeset=1"
+    line_to_add="""
+    options nvidia-drm modeset=1
+    options nvidia NVreg_PreserveVideoMemoryAllocations=1
+    """
 
     # Check if the config file exists
     if [ ! -e "$config_file" ]; then

--- a/install-scripts/xdph.sh
+++ b/install-scripts/xdph.sh
@@ -35,7 +35,7 @@ fi
 
 # Clone and build xdg-desktop-portal-hyprland
 printf "${NOTE} Installing xdg-desktop-portal-hyprland...\n"
-if git clone --recursive https://github.com/hyprwm/xdg-desktop-portal-hyprland; then
+if git clone --branch v1.3.0 --recursive https://github.com/hyprwm/xdg-desktop-portal-hyprland; then
     cd xdg-desktop-portal-hyprland || exit 1
     make all
     if sudo make install 2>&1 | tee -a "$MLOG" ; then


### PR DESCRIPTION
# Pull Request

## Description

- xdg-desktop-portal-hyprland after tag v1.3.0 drop make for building. So I just pin v1.3.0 :)
- nvidia=drm driver without `NVreg_PreserveVideoMemoryAllocations=1` break hyprland suspend. I add this line to nvidia.sh [as it is written in the wiki](https://wiki.hyprland.org/Nvidia/#fixing-suspendwakeup-issues)

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)


