### PR TITLE
Removed chmod from manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,6 @@ sudo nano /etc/apt/sources.list
 ```bash
 git clone --depth=1 https://github.com/JaKooLit/Debian-Hyprland.git ~/Debian-Hyprland
 cd ~/Debian-Hyprland
-chmod +x install.sh
 ./install.sh
 ```
 <p align="center">


### PR DESCRIPTION
isntall.sh is already executable

# Pull Request

## Description

There is no need to  to run chmod +x on the installation file as its permissions are set to 755

therefore the command can be removed from the guide 


