### PR TITLE
Add manual stack installer for building Hyprland from source

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,260 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is the **KooL Debian-Hyprland** project - an automated installer for the Hyprland window manager on Debian Testing (Trixie) and SID (unstable). The project provides a comprehensive installation script that sets up Hyprland with a complete desktop environment, themes, and customizations.
+
+**Important Context:**
+- Hyprland is a **bleeding-edge** dynamic tiling Wayland compositor
+- This installer addresses the fact that Debian/Ubuntu's packaged Hyprland versions are extremely outdated
+- The project builds most components from source to ensure compatibility and latest features
+- Hyprland requires C++26 standard support (gcc>=15 or clang>=19)
+
+**Key Features:**
+- Automated Hyprland installation with dependencies
+- Pre-configured dotfiles and themes
+- Support for NVIDIA GPUs
+- Modular installation system
+- Interactive user selection interface
+- Comprehensive logging and error handling
+
+## Architecture
+
+### Core Components
+
+**Main Scripts:**
+- `install.sh` - Main installation orchestrator with whiptail UI
+- `auto-install.sh` - One-line installer for remote execution
+- `preset.sh` - Preset configuration file for automated installations
+- `uninstall.sh` - Guided removal script
+
+**Install Scripts Directory (`install-scripts/`):**
+- `Global_functions.sh` - Shared utility functions library
+- `00-dependencies.sh` - System dependencies and build tools
+- `01-hypr-pkgs.sh` - Hyprland ecosystem packages
+- `02-pre-cleanup.sh` - Pre-installation cleanup
+- `03-Final-Check.sh` - Post-installation validation
+- Component-specific scripts: `hyprland.sh`, `waybar.sh`, `rofi-wayland.sh`, etc.
+
+### Script Architecture Pattern
+
+All install scripts follow this standardized structure:
+
+```bash
+#!/bin/bash
+# Package arrays definition
+packages=( package1 package2 package3 )
+
+# Navigate to parent directory
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+PARENT_DIR="$SCRIPT_DIR/.."
+cd "$PARENT_DIR"
+
+# Source shared functions
+source Global_functions.sh
+
+# Unique timestamped log file
+LOG="Install-Logs/install-$(date +%d-%H%M%S)_component.log"
+
+# Installation with progress tracking
+for PKG in "${packages[@]}"; do
+    install_package "$PKG" "$LOG"
+done
+```
+
+## Common Development Tasks
+
+### Running the Installation
+
+**Standard Installation:**
+```bash
+chmod +x install.sh
+./install.sh
+```
+
+**With Preset Configuration:**
+```bash
+./install.sh --preset preset.sh
+```
+
+**Auto-installation (remote):**
+```bash
+sh <(curl -L https://raw.githubusercontent.com/JaKooLit/Debian-Hyprland/main/auto-install.sh)
+```
+
+### Testing Individual Components
+
+**Run specific install scripts:**
+```bash
+# Must be run from repository root, not inside install-scripts/
+./install-scripts/component.sh
+```
+
+**Example component installations:**
+```bash
+./install-scripts/gtk_themes.sh     # Install GTK themes
+./install-scripts/sddm.sh           # Install SDDM login manager
+./install-scripts/fonts.sh          # Install fonts
+./install-scripts/dotfiles.sh       # Install dotfiles
+```
+
+### Validation and Debugging
+
+**Check installation logs:**
+```bash
+# Logs are created in Install-Logs/ directory
+ls -la Install-Logs/
+tail -f Install-Logs/install-$(date +%d-%H%M%S)_component.log
+```
+
+**Validate essential packages:**
+```bash
+./install-scripts/03-Final-Check.sh
+```
+
+**Test prerequisite checks:**
+```bash
+# Check if user can install from source
+grep -E "^deb-src" /etc/apt/sources.list
+```
+
+## Key Functions (Global_functions.sh)
+
+**Package Management:**
+- `install_package "$PKG" "$LOG"` - Install APT package with progress bar
+- `build_dep "$PKG"` - Install build dependencies
+- `cargo_install "$PKG"` - Install Rust package via Cargo
+- `re_install_package "$PKG"` - Force reinstall package
+- `uninstall_package "$PKG"` - Remove package with validation
+
+**Progress and Logging:**
+- `show_progress $PID "$package_name"` - Animated progress indicator
+- All functions log to timestamped files in `Install-Logs/`
+- Color-coded output: OK, ERROR, NOTE, INFO, WARN
+
+## Source Building Patterns
+
+Many components are built from source. Common patterns:
+
+**Rust/Cargo Projects:**
+```bash
+git clone --recursive -b $tag https://github.com/repo.git
+cd repo
+source "$HOME/.cargo/env"
+cargo build --release
+sudo cp target/release/binary /usr/bin/
+```
+
+**Meson/Ninja Projects:**
+```bash
+meson setup build
+ninja -C build
+sudo ninja -C build install
+```
+
+## System Requirements
+
+**Operating System:**
+- Debian Testing (Trixie) or SID (unstable)
+- **NOT compatible with Debian Stable (Bookworm)**
+- Rolling release distros (Fedora, OpenSUSE) likely work well
+- Ubuntu/Pop!_OS may have major compatibility issues due to outdated packages
+
+**Prerequisites:**
+- Non-root user with sudo privileges
+- Uncommented `deb-src` lines in `/etc/apt/sources.list`
+- C++26 compiler support (gcc>=15 or clang>=19)
+- For NVIDIA users: nouveau driver uninstalled (if using proprietary drivers)
+
+**Hardware Support:**
+- NVIDIA GPU support via `nvidia.sh` script (requires special configuration)
+- ASUS ROG laptop support via `rog.sh` script
+- Bluetooth configuration via `bluetooth.sh` script
+
+**Hyprland Core Dependencies:**
+- aquamarine
+- hyprlang
+- hyprcursor
+- hyprutils
+- hyprgraphics
+- hyprwayland-scanner (build-only)
+
+## Important Notes
+
+**Installation Behavior:**
+- Scripts check for existing packages before installation
+- Logs are timestamped and stored in `Install-Logs/`
+- Failed installations continue with warnings
+- Source-built packages install to `/usr/local/bin/` or `/usr/bin/`
+
+**Common Issues:**
+- Scripts must be run from repository root directory
+- SDDM installation requires stopping other login managers first
+- Network issues during source builds (swww, hyprlock, etc.)
+- NVIDIA configuration requires system reboot
+- GDM may have compatibility issues with Hyprland
+- VM installations require special graphics configuration (virgl, mesa)
+
+**File Locations:**
+- Install logs: `Install-Logs/`
+- Configuration backups: Created automatically
+- Dotfiles: Downloaded from separate repository branch
+- Themes: Installed to `/usr/share/themes/`
+
+## Customization
+
+**Package Selection:**
+- Edit `install-scripts/01-hypr-pkgs.sh` to modify package lists
+- Use `preset.sh` for automated installations
+- Individual component scripts can be run separately
+
+**Preset Configuration:**
+```bash
+# Example preset.sh entries
+gtk_themes="ON"
+bluetooth="ON"
+thunar="ON"
+dots="ON"
+nvidia="OFF"
+```
+
+## Uninstallation
+
+**Guided Removal:**
+```bash
+chmod +x uninstall.sh
+./uninstall.sh
+```
+
+The uninstall script provides:
+- Interactive package selection
+- Configuration directory removal
+- Locally-built package cleanup
+- System stability warnings
+
+## Hyprland Ecosystem Context
+
+**About Hyprland:**
+- Dynamic tiling Wayland compositor written in C++
+- Extremely bleeding-edge with rapid development
+- Requires latest dependencies and compiler support
+- Not meant to be a full Desktop Environment - users must configure their own ecosystem
+
+**Why This Installer Exists:**
+- Official Debian/Ubuntu packages are extremely outdated and unusable
+- Building from source requires complex dependency management
+- This project automates the entire stack compilation and configuration
+- Provides a complete, working Hyprland setup with dotfiles and themes
+
+**Related Projects:**
+- [Hyprland-Dots](https://github.com/JaKooLit/Hyprland-Dots) - Centralized dotfiles repository
+- [Ubuntu-Hyprland](https://github.com/JaKooLit/Ubuntu-Hyprland) - Ubuntu-specific installer
+- [Wallpaper-Bank](https://github.com/JaKooLit/Wallpaper-Bank) - Wallpaper collection
+
+**Support Resources:**
+- [Hyprland Wiki](https://wiki.hyprland.org/) - Official documentation
+- [FAQ](https://github.com/JaKooLit/Hyprland-Dots/wiki/FAQ) - Common questions
+- [Keybinds](https://github.com/JaKooLit/Hyprland-Dots/wiki/Keybinds) - Default shortcuts
+- [Discord](https://discord.gg/kool-tech-world) - Community support

--- a/install-manual-stack.sh
+++ b/install-manual-stack.sh
@@ -1,0 +1,170 @@
+#!/bin/bash
+# 💫 https://github.com/JaKooLit 💫 #
+# Manual Stack Installer - Build entire Hyprland stack from source #
+# Based on Hyprland wiki recommendations #
+
+clear
+
+# Set some colors for output messages
+OK="$(tput setaf 2)[OK]$(tput sgr0)"
+ERROR="$(tput setaf 1)[ERROR]$(tput sgr0)"
+NOTE="$(tput setaf 3)[NOTE]$(tput sgr0)"
+INFO="$(tput setaf 4)[INFO]$(tput sgr0)"
+WARN="$(tput setaf 1)[WARN]$(tput sgr0)"
+CAT="$(tput setaf 6)[ACTION]$(tput sgr0)"
+MAGENTA="$(tput setaf 5)"
+ORANGE="$(tput setaf 214)"
+WARNING="$(tput setaf 1)"
+YELLOW="$(tput setaf 3)"
+GREEN="$(tput setaf 2)"
+BLUE="$(tput setaf 4)"
+SKY_BLUE="$(tput setaf 6)"
+RESET="$(tput sgr0)"
+
+printf "\n%.0s" {1..2}  
+echo -e "\e[35m
+	╦╔═┌─┐┌─┐╦    ╦ ╦┬ ┬┌─┐┬─┐┬  ┌─┐┌┐┌┌┬┐
+	╠╩╗│ ││ │║    ╠═╣└┬┘├─┘├┬┘│  ├─┤│││ ││ MANUAL STACK
+	╩ ╩└─┘└─┘╩═╝  ╩ ╩ ┴ ┴  ┴└─┴─┘┴ ┴┘└┘─┴┘ Debian Build
+\e[0m"
+printf "\n%.0s" {1..1}
+
+# Display warning message
+echo -e "${WARNING}MANUAL STACK BUILD${RESET}: This will build the entire Hyprland stack from source."
+echo -e "This follows the Hyprland wiki recommendation to build everything manually." 
+echo -e "${WARNING}This process takes significantly longer but ensures latest compatibility.${RESET}"
+echo
+echo -e "${NOTE}Build process includes:${RESET}"
+echo -e "  1. Base dependencies"
+echo -e "  2. Wayland stack (wayland, wayland-protocols, libdisplay-info)"
+echo -e "  3. Hypr dependencies (hyprutils, hyprlang, hyprcursor, aquamarine, etc.)"
+echo -e "  4. Hyprland itself"
+echo -e "  5. Additional components (hyprlock, hypridle, etc.)"
+echo
+
+# Prompt user to continue or exit
+read -rp "Do you want to continue with the manual stack build? [y/N]: " confirm
+case "$confirm" in
+    [yY][eE][sS]|[yY])
+        echo -e "${OK} Continuing with manual stack build..."
+        ;;
+    *)
+        echo -e "${NOTE} You chose not to continue. Exiting..."
+        exit 1
+        ;;
+esac
+
+# Create Directory for Install Logs
+if [ ! -d Install-Logs ]; then
+    mkdir Install-Logs
+fi
+
+# Set the name of the log file to include the current date and time
+LOG="Install-Logs/01-Manual-Stack-Install-$(date +%d-%H%M%S).log"
+
+# Check if running as root. If root, script will exit
+if [[ $EUID -eq 0 ]]; then
+    echo "${ERROR}  This script should ${WARNING}NOT${RESET} be executed as root!! Exiting......." | tee -a "$LOG"
+    printf "\n%.0s" {1..2} 
+    exit 1
+fi
+
+# Function to execute a script if it exists and make it executable
+execute_script() {
+    local script="$1"
+    local script_path="install-scripts/$script"
+    if [ -f "$script_path" ]; then
+        chmod +x "$script_path"
+        if [ -x "$script_path" ]; then
+            env "$script_path"
+        else
+            echo "Failed to make script '$script' executable." | tee -a "$LOG"
+        fi
+    else
+        echo "Script '$script' not found in 'install-scripts'." | tee -a "$LOG"
+    fi
+}
+
+echo "👌 ${OK} 🇵🇭 ${MAGENTA}KooL..${RESET} ${SKY_BLUE}Building entire stack manually...${RESET}" | tee -a "$LOG"
+
+sleep 1
+printf "\n%.0s" {1..1}
+
+# Check compiler requirements
+echo "${INFO} Checking ${SKY_BLUE}compiler requirements...${RESET}" | tee -a "$LOG"
+gcc_version=$(gcc -dumpversion | cut -d. -f1)
+if [ "$gcc_version" -lt 15 ]; then
+    echo "${WARN} GCC version $gcc_version detected. Hyprland requires GCC >= 15 for C++26 support." | tee -a "$LOG"
+    echo "${NOTE} Attempting to continue, but you may need a newer compiler..." | tee -a "$LOG"
+fi
+
+echo "${INFO} Installing ${SKY_BLUE}base dependencies for manual build...${RESET}" | tee -a "$LOG"
+sleep 1
+execute_script "00-manual-stack-dependencies.sh"
+
+echo "${INFO} Building ${SKY_BLUE}Wayland stack from source...${RESET}" | tee -a "$LOG"
+sleep 1
+execute_script "01-manual-wayland-stack.sh"
+
+echo "${INFO} Building ${SKY_BLUE}Hypr dependencies from source...${RESET}" | tee -a "$LOG"
+sleep 1
+execute_script "02-manual-hypr-dependencies.sh"
+
+echo "${INFO} Building ${SKY_BLUE}Hyprland from source...${RESET}" | tee -a "$LOG"
+sleep 1
+execute_script "03-manual-hyprland.sh"
+
+echo "${INFO} Building ${SKY_BLUE}additional Hypr components...${RESET}" | tee -a "$LOG"
+sleep 1
+execute_script "hyprlock.sh"
+sleep 1
+execute_script "hypridle.sh"
+
+clear
+printf "\n%.0s" {1..2}
+
+# Check if Hyprland was built successfully
+if command -v Hyprland &> /dev/null; then
+    printf "\n ${OK} 👌 Hyprland manual stack build completed successfully!"
+    printf "\n${CAT} All components built from source as recommended by Hyprland wiki\n"
+    sleep 2
+    printf "\n%.0s" {1..2}
+
+    printf "${SKY_BLUE}Thank you${RESET} 🫰 for using 🇵🇭 ${MAGENTA}KooL's Manual Hyprland Build${RESET}. ${YELLOW}Enjoy and Have a good day!${RESET}"
+    printf "\n%.0s" {1..2}
+
+    printf "\n${NOTE} You can start Hyprland by typing ${SKY_BLUE}Hyprland${RESET} (note the capital H!).\n"
+    printf "\n${NOTE} It is ${YELLOW}highly recommended to reboot${RESET} your system for all library paths to be updated.\n\n"
+    
+    printf "\n${INFO} Manual build locations:${RESET}\n"
+    printf "  - Libraries: /usr/local/lib\n"
+    printf "  - Binaries: /usr/local/bin and /usr/bin\n"
+    printf "  - Source builds: ~/hypr-source-builds\n\n"
+
+    while true; do
+        echo -n "${CAT} Would you like to reboot now? (y/n): "
+        read HYP
+        HYP=$(echo "$HYP" | tr '[:upper:]' '[:lower:]')
+
+        if [[ "$HYP" == "y" || "$HYP" == "yes" ]]; then
+            echo "${INFO} Rebooting now..."
+            systemctl reboot 
+            break
+        elif [[ "$HYP" == "n" || "$HYP" == "no" ]]; then
+            echo "👌 ${OK} You chose NOT to reboot"
+            printf "\n%.0s" {1..1}
+            echo "${INFO} Remember to update your library paths or reboot before starting Hyprland"
+            printf "\n%.0s" {1..1}
+            break
+        else
+            echo "${WARN} Invalid response. Please answer with 'y' or 'n'."
+        fi
+    done
+else
+    # Print error message if Hyprland is not found
+    printf "\n${WARN} Hyprland manual build may have failed. Please check the logs in Install-Logs/ directory..."
+    printf "\n%.0s" {1..3}
+    exit 1
+fi
+
+printf "\n%.0s" {1..2}

--- a/install-scripts/00-manual-stack-dependencies.sh
+++ b/install-scripts/00-manual-stack-dependencies.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+# 💫 https://github.com/JaKooLit 💫 #
+# Manual Stack Dependencies - Build entire Hyprland stack from source #
+# Based on Hyprland wiki recommendations for building manually #
+
+# Base build dependencies needed for manual compilation
+base_dependencies=(
+    build-essential
+    cmake
+    cmake-extras
+    curl
+    findutils
+    gawk
+    gettext
+    gettext-base
+    git
+    glslang-tools
+    gobject-introspection
+    hwdata
+    jq
+    meson
+    ninja-build
+    openssl
+    psmisc
+    python3-mako
+    python3-markdown
+    python3-markupsafe
+    python3-yaml
+    python3-pyquery
+    spirv-tools
+    unzip
+    vulkan-validationlayers
+    vulkan-utility-libraries-dev
+    xdg-desktop-portal
+    xwayland
+    # Additional dependencies for manual builds
+    libfontconfig-dev
+    libffi-dev
+    libxml2-dev
+    libdrm-dev
+    libxkbcommon-x11-dev
+    libxkbregistry-dev
+    libxkbcommon-dev
+    libpixman-1-dev
+    libudev-dev
+    libseat-dev
+    seatd
+    libxcb-dri3-dev
+    libegl-dev
+    libgles2-mesa-dev
+    libegl1-mesa-dev
+    libinput-bin
+    libinput-dev
+    libxcb-composite0-dev
+    libavutil-dev
+    libavcodec-dev
+    libavformat-dev
+    libxcb-ewmh2
+    libxcb-ewmh-dev
+    libxcb-present-dev
+    libxcb-icccm4-dev
+    libxcb-render-util0-dev
+    libxcb-res0-dev
+    libxcb-xinput-dev
+    libtoml11-dev
+    libre2-dev
+    libpam0g-dev
+    fontconfig
+    bc
+    binutils
+    libc6
+    libcairo2
+)
+
+## WARNING: DO NOT EDIT BEYOND THIS LINE IF YOU DON'T KNOW WHAT YOU ARE DOING! ##
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Change the working directory to the parent directory of the script
+PARENT_DIR="$SCRIPT_DIR/.."
+cd "$PARENT_DIR" || { echo "${ERROR} Failed to change directory to $PARENT_DIR"; exit 1; }
+
+# Source the global functions script
+if ! source "$(dirname "$(readlink -f "$0")")/Global_functions.sh"; then
+  echo "Failed to source Global_functions.sh"
+  exit 1
+fi
+
+# Set the name of the log file to include the current date and time
+LOG="Install-Logs/install-$(date +%d-%H%M%S)_manual-stack-dependencies.log"
+
+# Installation of base dependencies for manual builds
+printf "\n%s - Installing ${SKY_BLUE}base dependencies for manual stack build....${RESET} \n" "${NOTE}"
+
+for PKG1 in "${base_dependencies[@]}"; do
+  install_package "$PKG1" "$LOG"
+done
+
+printf "\n${OK} Base dependencies for manual stack build installed successfully!\n"
+printf "\n%.0s" {1..2}

--- a/install-scripts/01-manual-wayland-stack.sh
+++ b/install-scripts/01-manual-wayland-stack.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# 💫 https://github.com/JaKooLit 💫 #
+# Manual Wayland Stack - Build wayland, wayland-protocols, libdisplay-info from source #
+
+## WARNING: DO NOT EDIT BEYOND THIS LINE IF YOU DON'T KNOW WHAT YOU ARE DOING! ##
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Change the working directory to the parent directory of the script
+PARENT_DIR="$SCRIPT_DIR/.."
+cd "$PARENT_DIR" || { echo "${ERROR} Failed to change directory to $PARENT_DIR"; exit 1; }
+
+# Source the global functions script
+if ! source "$(dirname "$(readlink -f "$0")")/Global_functions.sh"; then
+  echo "Failed to source Global_functions.sh"
+  exit 1
+fi
+
+# Set the name of the log file to include the current date and time
+LOG="Install-Logs/install-$(date +%d-%H%M%S)_manual-wayland.log"
+
+printf "\n${NOTE} Building ${SKY_BLUE}Wayland stack from source${RESET}...\n"
+
+# Create build directory
+BUILD_DIR="$HOME/hypr-source-builds"
+mkdir -p "$BUILD_DIR"
+cd "$BUILD_DIR"
+
+# Function to build wayland from source
+build_wayland() {
+    printf "\n${INFO} Building ${SKY_BLUE}wayland${RESET} from source...\n"
+    
+    if [ -d "wayland" ]; then
+        rm -rf wayland
+    fi
+    
+    (
+        git clone https://gitlab.freedesktop.org/wayland/wayland.git
+        cd wayland
+        # Get latest stable release tag
+        git checkout $(git describe --tags $(git rev-list --tags --max-count=1))
+        meson setup build --prefix=/usr/local --buildtype=release
+        ninja -C build
+        sudo ninja -C build install
+        sudo ldconfig
+    ) >> "$LOG" 2>&1
+    
+    if [ $? -eq 0 ]; then
+        printf "${OK} Wayland built and installed successfully!\n"
+    else
+        printf "${ERROR} Failed to build wayland. Check $LOG for details.\n"
+        return 1
+    fi
+}
+
+# Function to build wayland-protocols from source
+build_wayland_protocols() {
+    printf "\n${INFO} Building ${SKY_BLUE}wayland-protocols${RESET} from source...\n"
+    
+    if [ -d "wayland-protocols" ]; then
+        rm -rf wayland-protocols
+    fi
+    
+    (
+        git clone https://gitlab.freedesktop.org/wayland/wayland-protocols.git
+        cd wayland-protocols
+        # Get latest stable release tag
+        git checkout $(git describe --tags $(git rev-list --tags --max-count=1))
+        meson setup build --prefix=/usr/local --buildtype=release
+        ninja -C build
+        sudo ninja -C build install
+    ) >> "$LOG" 2>&1
+    
+    if [ $? -eq 0 ]; then
+        printf "${OK} Wayland-protocols built and installed successfully!\n"
+    else
+        printf "${ERROR} Failed to build wayland-protocols. Check $LOG for details.\n"
+        return 1
+    fi
+}
+
+# Function to build libdisplay-info from source
+build_libdisplay_info() {
+    printf "\n${INFO} Building ${SKY_BLUE}libdisplay-info${RESET} from source...\n"
+    
+    if [ -d "libdisplay-info" ]; then
+        rm -rf libdisplay-info
+    fi
+    
+    (
+        git clone https://gitlab.freedesktop.org/emersion/libdisplay-info.git
+        cd libdisplay-info
+        # Get latest stable release tag
+        git checkout $(git describe --tags $(git rev-list --tags --max-count=1))
+        meson setup build --prefix=/usr/local --buildtype=release
+        ninja -C build
+        sudo ninja -C build install
+        sudo ldconfig
+    ) >> "$LOG" 2>&1
+    
+    if [ $? -eq 0 ]; then
+        printf "${OK} libdisplay-info built and installed successfully!\n"
+    else
+        printf "${ERROR} Failed to build libdisplay-info. Check $LOG for details.\n"
+        return 1
+    fi
+}
+
+# Build in dependency order
+build_wayland
+build_wayland_protocols  
+build_libdisplay_info
+
+printf "\n${OK} Wayland stack built successfully from source!\n"
+printf "\n%.0s" {1..2}

--- a/install-scripts/02-manual-hypr-dependencies.sh
+++ b/install-scripts/02-manual-hypr-dependencies.sh
@@ -1,0 +1,186 @@
+#!/bin/bash
+# 💫 https://github.com/JaKooLit 💫 #
+# Manual Hypr Dependencies - Build all hypr* dependencies from source #
+
+## WARNING: DO NOT EDIT BEYOND THIS LINE IF YOU DON'T KNOW WHAT YOU ARE DOING! ##
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Change the working directory to the parent directory of the script
+PARENT_DIR="$SCRIPT_DIR/.."
+cd "$PARENT_DIR" || { echo "${ERROR} Failed to change directory to $PARENT_DIR"; exit 1; }
+
+# Source the global functions script
+if ! source "$(dirname "$(readlink -f "$0")")/Global_functions.sh"; then
+  echo "Failed to source Global_functions.sh"
+  exit 1
+fi
+
+# Set the name of the log file to include the current date and time
+LOG="Install-Logs/install-$(date +%d-%H%M%S)_manual-hypr-deps.log"
+
+printf "\n${NOTE} Building ${SKY_BLUE}Hypr dependencies from source${RESET}...\n"
+
+# Create build directory
+BUILD_DIR="$HOME/hypr-source-builds"
+mkdir -p "$BUILD_DIR"
+cd "$BUILD_DIR"
+
+# Function to build hyprwayland-scanner from source
+build_hyprwayland_scanner() {
+    printf "\n${INFO} Building ${SKY_BLUE}hyprwayland-scanner${RESET} from source...\n"
+    
+    if [ -d "hyprwayland-scanner" ]; then
+        rm -rf hyprwayland-scanner
+    fi
+    
+    (
+        git clone --recursive https://github.com/hyprwm/hyprwayland-scanner.git
+        cd hyprwayland-scanner
+        cmake -DCMAKE_INSTALL_PREFIX=/usr/local -B build
+        cmake --build build -j$(nproc)
+        sudo cmake --install build
+    ) >> "$LOG" 2>&1
+    
+    if [ $? -eq 0 ]; then
+        printf "${OK} hyprwayland-scanner built and installed successfully!\n"
+    else
+        printf "${ERROR} Failed to build hyprwayland-scanner. Check $LOG for details.\n"
+        return 1
+    fi
+}
+
+# Function to build hyprutils from source
+build_hyprutils() {
+    printf "\n${INFO} Building ${SKY_BLUE}hyprutils${RESET} from source...\n"
+    
+    if [ -d "hyprutils" ]; then
+        rm -rf hyprutils
+    fi
+    
+    (
+        git clone --recursive https://github.com/hyprwm/hyprutils.git
+        cd hyprutils
+        cmake -DCMAKE_INSTALL_PREFIX=/usr/local -B build
+        cmake --build build -j$(nproc)
+        sudo cmake --install build
+        sudo ldconfig
+    ) >> "$LOG" 2>&1
+    
+    if [ $? -eq 0 ]; then
+        printf "${OK} hyprutils built and installed successfully!\n"
+    else
+        printf "${ERROR} Failed to build hyprutils. Check $LOG for details.\n"
+        return 1
+    fi
+}
+
+# Function to build hyprlang from source  
+build_hyprlang() {
+    printf "\n${INFO} Building ${SKY_BLUE}hyprlang${RESET} from source...\n"
+    
+    if [ -d "hyprlang" ]; then
+        rm -rf hyprlang
+    fi
+    
+    (
+        git clone --recursive https://github.com/hyprwm/hyprlang.git
+        cd hyprlang
+        cmake -DCMAKE_INSTALL_PREFIX=/usr/local -B build
+        cmake --build build -j$(nproc)
+        sudo cmake --install build
+        sudo ldconfig
+    ) >> "$LOG" 2>&1
+    
+    if [ $? -eq 0 ]; then
+        printf "${OK} hyprlang built and installed successfully!\n"
+    else
+        printf "${ERROR} Failed to build hyprlang. Check $LOG for details.\n"
+        return 1
+    fi
+}
+
+# Function to build hyprcursor from source
+build_hyprcursor() {
+    printf "\n${INFO} Building ${SKY_BLUE}hyprcursor${RESET} from source...\n"
+    
+    if [ -d "hyprcursor" ]; then
+        rm -rf hyprcursor
+    fi
+    
+    (
+        git clone --recursive https://github.com/hyprwm/hyprcursor.git
+        cd hyprcursor
+        cmake -DCMAKE_INSTALL_PREFIX=/usr/local -B build
+        cmake --build build -j$(nproc)
+        sudo cmake --install build
+        sudo ldconfig
+    ) >> "$LOG" 2>&1
+    
+    if [ $? -eq 0 ]; then
+        printf "${OK} hyprcursor built and installed successfully!\n"
+    else
+        printf "${ERROR} Failed to build hyprcursor. Check $LOG for details.\n"
+        return 1
+    fi
+}
+
+# Function to build aquamarine from source
+build_aquamarine() {
+    printf "\n${INFO} Building ${SKY_BLUE}aquamarine${RESET} from source...\n"
+    
+    if [ -d "aquamarine" ]; then
+        rm -rf aquamarine
+    fi
+    
+    (
+        git clone --recursive https://github.com/hyprwm/aquamarine.git
+        cd aquamarine
+        cmake -DCMAKE_INSTALL_PREFIX=/usr/local -B build
+        cmake --build build -j$(nproc)
+        sudo cmake --install build
+        sudo ldconfig
+    ) >> "$LOG" 2>&1
+    
+    if [ $? -eq 0 ]; then
+        printf "${OK} aquamarine built and installed successfully!\n"
+    else
+        printf "${ERROR} Failed to build aquamarine. Check $LOG for details.\n"
+        return 1
+    fi
+}
+
+# Function to build hyprgraphics from source
+build_hyprgraphics() {
+    printf "\n${INFO} Building ${SKY_BLUE}hyprgraphics${RESET} from source...\n"
+    
+    if [ -d "hyprgraphics" ]; then
+        rm -rf hyprgraphics
+    fi
+    
+    (
+        git clone --recursive https://github.com/hyprwm/hyprgraphics.git
+        cd hyprgraphics
+        cmake -DCMAKE_INSTALL_PREFIX=/usr/local -B build
+        cmake --build build -j$(nproc)
+        sudo cmake --install build
+        sudo ldconfig
+    ) >> "$LOG" 2>&1
+    
+    if [ $? -eq 0 ]; then
+        printf "${OK} hyprgraphics built and installed successfully!\n"
+    else
+        printf "${ERROR} Failed to build hyprgraphics. Check $LOG for details.\n"
+        return 1
+    fi
+}
+
+# Build in dependency order
+build_hyprwayland_scanner
+build_hyprutils
+build_hyprlang
+build_hyprcursor
+build_aquamarine
+build_hyprgraphics
+
+printf "\n${OK} All Hypr dependencies built successfully from source!\n"
+printf "\n%.0s" {1..2}

--- a/install-scripts/03-manual-hyprland.sh
+++ b/install-scripts/03-manual-hyprland.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+# 💫 https://github.com/JaKooLit 💫 #
+# Manual Hyprland Build - Build Hyprland itself from source #
+
+## WARNING: DO NOT EDIT BEYOND THIS LINE IF YOU DON'T KNOW WHAT YOU ARE DOING! ##
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Change the working directory to the parent directory of the script
+PARENT_DIR="$SCRIPT_DIR/.."
+cd "$PARENT_DIR" || { echo "${ERROR} Failed to change directory to $PARENT_DIR"; exit 1; }
+
+# Source the global functions script
+if ! source "$(dirname "$(readlink -f "$0")")/Global_functions.sh"; then
+  echo "Failed to source Global_functions.sh"
+  exit 1
+fi
+
+# Set the name of the log file to include the current date and time
+LOG="Install-Logs/install-$(date +%d-%H%M%S)_manual-hyprland.log"
+
+printf "\n${NOTE} Building ${SKY_BLUE}Hyprland from source${RESET}...\n"
+
+# Create build directory
+BUILD_DIR="$HOME/hypr-source-builds"
+mkdir -p "$BUILD_DIR"
+cd "$BUILD_DIR"
+
+# Function to build Hyprland from source
+build_hyprland() {
+    printf "\n${INFO} Building ${SKY_BLUE}Hyprland${RESET} from source...\n"
+    
+    if [ -d "Hyprland" ]; then
+        rm -rf Hyprland
+    fi
+    
+    (
+        git clone --recursive https://github.com/hyprwm/Hyprland.git
+        cd Hyprland
+        
+        # Use the latest stable release
+        git checkout $(git describe --tags $(git rev-list --tags --max-count=1))
+        
+        # Update PKG_CONFIG_PATH to find our manually built dependencies
+        export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig:/usr/local/share/pkgconfig:$PKG_CONFIG_PATH"
+        export LD_LIBRARY_PATH="/usr/local/lib:/usr/local/lib64:$LD_LIBRARY_PATH"
+        
+        # Build using CMake (recommended method)
+        make all
+        sudo make install
+        
+        # Copy desktop file for display managers
+        sudo cp ./example/hyprland.desktop /usr/share/wayland-sessions/
+        
+    ) >> "$LOG" 2>&1
+    
+    if [ $? -eq 0 ]; then
+        printf "${OK} Hyprland built and installed successfully!\n"
+        printf "${NOTE} Hyprland desktop file installed to /usr/share/wayland-sessions/\n"
+    else
+        printf "${ERROR} Failed to build Hyprland. Check $LOG for details.\n"
+        return 1
+    fi
+}
+
+# Function to build xdg-desktop-portal-hyprland from source
+build_xdph() {
+    printf "\n${INFO} Building ${SKY_BLUE}xdg-desktop-portal-hyprland${RESET} from source...\n"
+    
+    if [ -d "xdg-desktop-portal-hyprland" ]; then
+        rm -rf xdg-desktop-portal-hyprland
+    fi
+    
+    (
+        git clone --recursive https://github.com/hyprwm/xdg-desktop-portal-hyprland.git
+        cd xdg-desktop-portal-hyprland
+        
+        # Update PKG_CONFIG_PATH for our dependencies
+        export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig:/usr/local/share/pkgconfig:$PKG_CONFIG_PATH"
+        
+        meson setup build --prefix=/usr/local --buildtype=release
+        ninja -C build
+        sudo ninja -C build install
+        
+    ) >> "$LOG" 2>&1
+    
+    if [ $? -eq 0 ]; then
+        printf "${OK} xdg-desktop-portal-hyprland built and installed successfully!\n"
+    else
+        printf "${ERROR} Failed to build xdg-desktop-portal-hyprland. Check $LOG for details.\n"
+        return 1
+    fi
+}
+
+# Check compiler version
+printf "\n${INFO} Checking compiler requirements...\n"
+gcc_version=$(gcc -dumpversion | cut -d. -f1)
+if [ "$gcc_version" -lt 15 ]; then
+    printf "${WARN} GCC version $gcc_version detected. Hyprland requires GCC >= 15 for C++26 support.\n"
+    printf "${NOTE} You may need to install a newer GCC version or use Clang >= 19.\n"
+fi
+
+# Update PKG_CONFIG_PATH and LD_LIBRARY_PATH for our manually built libraries
+export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig:/usr/local/share/pkgconfig:$PKG_CONFIG_PATH"
+export LD_LIBRARY_PATH="/usr/local/lib:/usr/local/lib64:$LD_LIBRARY_PATH"
+
+# Add to user's profile for future sessions
+if ! grep -q "PKG_CONFIG_PATH.*usr/local" ~/.bashrc; then
+    echo 'export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig:/usr/local/share/pkgconfig:$PKG_CONFIG_PATH"' >> ~/.bashrc
+    echo 'export LD_LIBRARY_PATH="/usr/local/lib:/usr/local/lib64:$LD_LIBRARY_PATH"' >> ~/.bashrc
+    printf "${NOTE} Updated ~/.bashrc with library paths for manually built components.\n"
+fi
+
+# Build Hyprland and portal
+build_hyprland
+build_xdph
+
+# Update dynamic linker cache
+sudo ldconfig
+
+printf "\n${OK} Manual Hyprland build completed!\n"
+printf "${NOTE} You may need to logout/login or reboot for all changes to take effect.\n"
+printf "\n%.0s" {1..2}


### PR DESCRIPTION
this PR Adds a comprehensive manual stack installer that builds the entire Hyprland ecosystem from source code, following the official Hyprland wiki recommendations for manual compilation.

Features:
- Main installer script (install-manual-stack.sh) with user prompts
- Base dependencies installer (00-manual-stack-dependencies.sh)
- Wayland stack builder (01-manual-wayland-stack.sh)
- Hypr dependencies builder (02-manual-hypr-dependencies.sh)
- Hyprland core builder (03-manual-hyprland.sh)
- Updated CLAUDE.md with comprehensive project documentation

The manual stack approach ensures maximum compatibility with bleeding-edge Hyprland features and addresses issues with outdated packaged versions in Debian/Ubuntu repositories.